### PR TITLE
feat: Adds RAG to chat with txt file

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -572,3 +572,20 @@ export async function saveFileEmbedding({
     );
   }
 }
+
+export async function getFileEmbeddingsByChatId({
+  chatId,
+}: { chatId: string }) {
+  try {
+    return await db
+      .select()
+      .from(fileEmbedding)
+      .where(eq(fileEmbedding.chatId, chatId))
+      .orderBy(asc(fileEmbedding.createdAt));
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get file embeddings by chat id',
+    );
+  }
+}


### PR DESCRIPTION
This PR adds following this
- `getFileEmbeddingsByChatId` to get all the embeddings for a chat
- Adds file context to the system prompt if there are file embeddings
- Adds file embeddings to the system prompt

Please refer screenshot with the same text file uploaded which has all the recipes 

and In chat I ask about specific recipe present int he txt file. 

![Screenshot 2025-05-21 at 1 06 42 AM](https://github.com/user-attachments/assets/21bd9a38-70fa-4600-a315-a5ed04a82b5a)

fileEmbedding DB screenshot
![Screenshot 2025-05-21 at 1 06 52 AM](https://github.com/user-attachments/assets/1df65888-7f04-4bc2-ac25-59ad57d3369b)
