### PR TITLE
feat: batch process embeddings upload to DB

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -629,3 +629,28 @@ export async function findSimilarEmbeddings({
     );
   }
 }
+
+export async function saveFileEmbeddings(
+  embeddings: Array<{
+    chatId: string;
+    fileName: string;
+    fileUrl: string;
+    fileType: string;
+    chunkIndex: number;
+    rowIndex: number | null;
+    colName: string | null;
+    content: string;
+    embedding: number[];
+    metadata: Record<string, any>;
+    createdAt: Date;
+  }>,
+) {
+  try {
+    return await db.insert(fileEmbedding).values(embeddings);
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to save file embeddings',
+    );
+  }
+}


### PR DESCRIPTION
This pull request updates function, `saveFileEmbeddings`, to handle batch persistence of file embeddings and updates the `processFile` function to use this new method instead of persisting each row individually. These changes improve database interaction efficiency and maintainability.

### Database Interaction Enhancements:
* **`lib/db/queries.ts`:** Added a new function, `saveFileEmbeddings`, to insert an array of file embeddings into the database. This function includes error handling to throw a `ChatSDKError` if the operation fails.

### Code Refactoring:
* **`lib/processor.ts`:** Updated the import statement to use `saveFileEmbeddings` instead of `saveFileEmbedding`.
* **`lib/processor.ts`:** Modified the `processFile` function to persist file embeddings in batches using the new `saveFileEmbeddings` function, replacing the previous approach of persisting each row individually. [[1]](diffhunk://#diff-6fdee568a48de000602c22c273f3a55e5db051c670681d2025db8561fc6f6b18L39-R41) [[2]](diffhunk://#diff-6fdee568a48de000602c22c273f3a55e5db051c670681d2025db8561fc6f6b18L61-R61)